### PR TITLE
EnvConfig wrapper

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -1,0 +1,170 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package config
+
+import ()
+
+// Config ---------------------------------------------------------------------
+
+// EnvConfig provides convenient access to settings for an environment.
+// It will first check "ENV.path", and if not found, return "PATH".
+// This makes it easy to provide default settings which can be overwritten
+// for each environment.
+//
+// To use it, initialize your config first.
+// Then create a new EnvConfig like this:
+// envConfig := config.EnvConfig{Env: "production", Config: &conf}
+type EnvConfig struct {
+	Env    string
+	Config *Config
+}
+
+// Get returns a nested config according to a dotted path.
+func (c *EnvConfig) Get(path string) (*Config, error) {
+	return c.Config.Get(path)
+}
+
+// Set a nested config according to a dotted path.
+func (c *EnvConfig) Set(path string, val interface{}) error {
+	return c.Config.Set(path, val)
+}
+
+// Bool returns a bool according to a dotted path.
+func (c *EnvConfig) Bool(path string) (bool, error) {
+	val, err := c.Config.Bool(c.Env + "." + path)
+	if err != nil {
+		val, err = c.Config.Bool(path)
+	}
+	return val, err
+}
+
+// UBool retirns a bool according to a dotted path or default value or false.
+func (c *EnvConfig) UBool(path string, defaults ...bool) bool {
+	value, err := c.Bool(path)
+
+	if err == nil {
+		return value
+	}
+
+	for _, def := range defaults {
+		return def
+	}
+	return false
+}
+
+// Float64 returns a float64 according to a dotted path.
+func (c *EnvConfig) Float64(path string) (float64, error) {
+	val, err := c.Config.Float64(c.Env + "." + path)
+	if err != nil {
+		val, err = c.Config.Float64(path)
+	}
+	return val, err
+}
+
+// UFloat64 returns a float64 according to a dotted path or default value or 0.
+func (c *EnvConfig) UFloat64(path string, defaults ...float64) float64 {
+	value, err := c.Float64(path)
+
+	if err == nil {
+		return value
+	}
+
+	for _, def := range defaults {
+		return def
+	}
+	return float64(0)
+}
+
+// Int returns an int according to a dotted path.
+func (c *EnvConfig) Int(path string) (int, error) {
+	val, err := c.Config.Int(c.Env + "." + path)
+	if err != nil {
+		val, err = c.Config.Int(path)
+	}
+	return val, err
+}
+
+// UInt returns an int according to a dotted path or default value or 0.
+func (c *EnvConfig) UInt(path string, defaults ...int) int {
+	value, err := c.Int(path)
+
+	if err == nil {
+		return value
+	}
+
+	for _, def := range defaults {
+		return def
+	}
+	return 0
+}
+
+// List returns a []interface{} according to a dotted path.
+func (c *EnvConfig) List(path string) ([]interface{}, error) {
+	val, err := c.Config.List(c.Env + "." + path)
+	if err != nil {
+		val, err = c.Config.List(path)
+	}
+	return val, err
+}
+
+// UList returns a []interface{} according to a dotted path or defaults or []interface{}.
+func (c *EnvConfig) UList(path string, defaults ...[]interface{}) []interface{} {
+	value, err := c.List(path)
+
+	if err == nil {
+		return value
+	}
+
+	for _, def := range defaults {
+		return def
+	}
+	return make([]interface{}, 0)
+}
+
+// Map returns a map[string]interface{} according to a dotted path.
+func (c *EnvConfig) Map(path string) (map[string]interface{}, error) {
+	val, err := c.Config.Map(c.Env + "." + path)
+	if err != nil {
+		val, err = c.Config.Map(path)
+	}
+	return val, err
+}
+
+// UMap returns a map[string]interface{} according to a dotted path or default or map[string]interface{}.
+func (c *EnvConfig) UMap(path string, defaults ...map[string]interface{}) map[string]interface{} {
+	value, err := c.Map(path)
+
+	if err == nil {
+		return value
+	}
+
+	for _, def := range defaults {
+		return def
+	}
+	return map[string]interface{}{}
+}
+
+// String returns a string according to a dotted path.
+func (c *EnvConfig) String(path string) (string, error) {
+	val, err := c.Config.String(c.Env + "." + path)
+	if err != nil {
+		val, err = c.Config.String(path)
+	}
+	return val, err
+}
+
+// UString returns a string according to a dotted path or default or "".
+func (c *EnvConfig) UString(path string, defaults ...string) string {
+	value, err := c.String(path)
+
+	if err == nil {
+		return value
+	}
+
+	for _, def := range defaults {
+		return def
+	}
+	return ""
+}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -1,0 +1,108 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	"testing"
+)
+
+var envYamlString = `
+string: "val"
+string2: "val2"
+int: 1
+int2: 2
+float: 1.1
+float2: 2.2
+list: [1]
+list2: [2]
+map:
+  key1: 1
+map2:
+  key1: 21
+dev:
+  string: "val11"
+  int: 11
+  float: 11.1
+  list: [11]
+  map:
+    key1: 11
+`
+
+var envConfigTests = []struct {
+	path string
+	kind string
+	want interface{}
+	ok   bool
+}{
+	// Get from env.
+	{"string", "String", "val11", true},
+	{"int", "Int", 11, true},
+	{"float", "Float64", 11.1, true},
+	{"list", "List", []interface{}{11}, true},
+	{"map", "Map", map[string]interface{}{"key1": 11}, true},
+
+	// Get from root.
+	{"string2", "String", "val2", true},
+	{"int2", "Int", 2, true},
+	{"float2", "Float64", 2.2, true},
+	{"list2", "List", []interface{}{2}, true},
+	{"map2", "Map", map[string]interface{}{"key1": 21}, true},
+}
+
+func TestEnvConfig(t *testing.T) {
+	cfg, err := ParseYaml(envYamlString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envCfg := &EnvConfig{Env: "dev", Config: cfg}
+	testEnvConfig(t, envCfg)
+}
+
+func testEnvConfig(t *testing.T, cfg *EnvConfig) {
+Loop:
+	for _, test := range envConfigTests {
+		var got interface{}
+		var err error
+		switch test.kind {
+		case "Bool":
+			got, err = cfg.Bool(test.path)
+		case "Float64":
+			got, err = cfg.Float64(test.path)
+		case "Int":
+			got, err = cfg.Int(test.path)
+		case "List":
+			got, err = cfg.List(test.path)
+		case "Map":
+			got, err = cfg.Map(test.path)
+		case "String":
+			got, err = cfg.String(test.path)
+		default:
+			t.Errorf("Unsupported kind %q", test.kind)
+			continue Loop
+		}
+		if test.ok {
+			if err != nil {
+				t.Errorf(`%s(%q) = "%v", got error: %v`, test.kind, test.path, test.want, err)
+			} else {
+				ok := false
+				switch test.kind {
+				case "List":
+					ok = equalList(got, test.want)
+				case "Map":
+					ok = equalMap(got, test.want)
+				default:
+					ok = got == test.want
+				}
+				if !ok {
+					t.Errorf(`%s(%q) = "%v", want "%v"`, test.kind, test.path, test.want, got)
+				}
+			}
+		} else {
+			if err == nil {
+				t.Errorf("%s(%q): expected error", test.kind, test.path)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added EnvConfig wrapper for convenient access to environment settings with fallback to default settings.
Also added some tests.

If the config key exists within the environment, it will be returned. Otherwise, the root is checked for the same key.

Usage:

Config:
```yaml
val: 22
defaultVal: "default"
production:
  val: 333
  strVal: "xx"
```

```go
envConfig := &EnvConfig{Env: "production", Config: cfg} 
envConfig.UInt("val") // returns 333, not 22
envConfig.UString("strVal") // returns "xx"
envConfig.UString("defaultVal")  // returns "default"
```

All accessors (string, int, float64, list, map) are duplicated on EnvConfig.