### PR TITLE
Allow null values in normalizeValue()

### DIFF
--- a/config.go
+++ b/config.go
@@ -500,7 +500,7 @@ func normalizeValue(value interface{}) (interface{}, error) {
 			node[key] = item
 		}
 		return node, nil
-	case bool, float64, int, string:
+	case bool, float64, int, string, nil:
 		return value, nil
 	}
 	return nil, fmt.Errorf("Unsupported type: %T", value)


### PR DESCRIPTION
This adds nil to the list of valid simple value types in normalizeValue().
Otherwise the you would get an "Unsupported type" error when parsing yaml/json content.