### PR TITLE
Issue parsing command line flags

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,18 +72,27 @@ func (cfg *Config) Flag() *Config {
 // Get all keys for given interface
 func getKeys(source interface{}, base ...string) [][]string {
 	acc := [][]string{}
+
+	// Copy "base" so that underlying slice array is not
+	// modified in recursive calls
+	nextBase := make([]string, len(base))
+	copy(nextBase, base)
+
 	switch c := source.(type) {
 	case map[string]interface{}:
 		for k, v := range c {
-			acc = append(acc, getKeys(v, append(base, k)...)...)
+			keys := getKeys(v, append(nextBase, k)...)
+			acc = append(acc, keys...)
 		}
 	case []interface{}:
 		for i, v := range c {
 			k := strconv.Itoa(i)
-			acc = append(acc, getKeys(v, append(base, k)...)...)
+			keys := getKeys(v, append(nextBase, k)...)
+			acc = append(acc, keys...)
 		}
 	default:
-		acc = append(acc, base)
+		acc = append(acc, nextBase)
+		return acc
 	}
 	return acc
 }

--- a/config_test.go
+++ b/config_test.go
@@ -293,6 +293,25 @@ func TestEnv(t *testing.T) {
 	}
 }
 
+func TestFlag(t *testing.T) {
+	cfg, err := ParseYaml(`
+map:
+  - listmap1:
+      nested1: value1
+      nested2: value2
+    listmap2: value3
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Args = append(os.Args, "-map-0-listmap2", "other")
+	cfg.Flag()
+	test, _ := cfg.String("map.0.listmap2")
+	if test != "other" {
+		t.Errorf(`"%s" != "%s"`, test, "other")
+	}
+}
+
 func TestUMethods(t *testing.T) {
 	cfg, err := ParseYaml(yamlString)
 	if err != nil {


### PR DESCRIPTION
I've found that when you have a configuration file where a 'm'ap contains a list of maps wich have more than one key/value' the values returned by getKey() are duplicated because of the 'base slice shares its storage array when called recursively and the new keys fit there.

Hope you find this useful and can get it merged in. Thanks for making this open source.
