### PR TITLE
Add EnvPrefix()

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,9 +39,19 @@ func (cfg *Config) Set(path string, val interface{}) error {
 
 // Fetch data from system env, based on existing config keys.
 func (cfg *Config) Env() *Config {
+	return cfg.EnvPrefix("")
+}
+
+// Fetch data from system env using prefix, based on existing config keys.
+func (cfg *Config) EnvPrefix(prefix string) *Config {
+	if prefix != "" {
+		prefix = strings.ToUpper(prefix) + "_"
+	}
+
 	keys := getKeys(cfg.Root)
 	for _, key := range keys {
-		if val, exist := syscall.Getenv(strings.ToUpper(strings.Join(key, "_"))); exist {
+		k := strings.ToUpper(strings.Join(key, "_"))
+		if val, exist := syscall.Getenv(prefix + k); exist {
 			cfg.Set(strings.Join(key, "."), val)
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -284,9 +284,24 @@ func TestEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	val := "test"
-	cfg.Set("map.key8", val)
+	cfg.Set("map.key8", "should be overwritten")
 	os.Setenv("MAP_KEY8", val)
 	cfg.Env()
+	test, _ := cfg.String("map.key8")
+	if test != val {
+		t.Errorf(`"%s" != "%s"`, test, val)
+	}
+}
+
+func TestEnvPrefix(t *testing.T) {
+	cfg, err := ParseYaml(yamlString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	val := "test"
+	cfg.Set("map.key8", "should be overwritten")
+	os.Setenv("PREFIX_MAP_KEY8", val)
+	cfg.EnvPrefix("prefix")
 	test, _ := cfg.String("map.key8")
 	if test != val {
 		t.Errorf(`"%s" != "%s"`, test, val)

--- a/doc.go
+++ b/doc.go
@@ -122,7 +122,9 @@ We can also specify the order of parsing:
     cfg.Flag().Env()
 
 In case of OS environment all existing at the moment of parsing keys will be scanned in OS environment,
-but in uppercase and the separator will be `_` instead of a `.`. In case of flags separator will be `-`.
+but in uppercase and the separator will be `_` instead of a `.`. If EnvPrefix() is used the given prefix
+will be used to lookup the environment variable, e.g PREFIX_FOO_BAR will set foo.bar.
+In case of flags separator will be `-`.
 In case of command line arguments possible to use regular dot notation syntax for all keys.
 For see existing keys we can run application with `-h`.
 


### PR DESCRIPTION
Same functionality as Env() except a prefix is used when looking up
environment variables to replace with. So a key that is looked up with
Env() as FOO_BAR will be BAZ_FOO_BAR if EnvPrefix("baz") is used.

Also updated TestEnv to ensure that the previously set value is
overwritten by the environment variable.

--

I needed this functionality to avoid environment variables clashing, thanks for the useful library 👍 