### PR TITLE
Update config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -565,6 +565,11 @@ func RenderJson(cfg interface{}) (string, error) {
 
 // YAML -----------------------------------------------------------------------
 
+// ParseYamlBytes reads a YAML configuration from the given []byte.
+func ParseYamlBytes(cfg []byte) (*Config, error) {
+	return parseYaml(cfg)
+}
+
 // ParseYaml reads a YAML configuration from the given string.
 func ParseYaml(cfg string) (*Config, error) {
 	return parseYaml([]byte(cfg))


### PR DESCRIPTION
Exposing ParseYamlBytes(cfg []byte) to decode an already existing `[]byte`, w/o casting it to a `string`.