### PR TITLE
fix error message when Set() under wrong parent type

### DIFF
--- a/config.go
+++ b/config.go
@@ -498,7 +498,7 @@ func Set(cfg interface{}, path string, value interface{}) error {
 		default:
 			return fmt.Errorf(
 				"Invalid type at %q: expected []interface{} or map[string]interface{}; got %T",
-				strings.Join(parts[:pos+1], "."), cfg)
+				strings.Join(parts[:pos+1], "."), c)
 		}
 	}
 


### PR DESCRIPTION
```
cfg.Set("foo", nil)
cfg.Set("foo.bar", 4)
```

Before:
`Invalid type at "foo.bar": expected []interface{} or map[string]interface{}; got map[string]interface {}
`
After:
`Invalid type at "foo.bar": expected []interface{} or map[string]interface{}; got <nil>`