### PR TITLE
[#15] add support for keys with dots

### DIFF
--- a/config.go
+++ b/config.go
@@ -383,7 +383,7 @@ func typeMismatch(expected string, got interface{}) error {
 
 // Get returns a child of the given value according to a dotted path.
 func Get(cfg interface{}, path string) (interface{}, error) {
-	parts := strings.Split(path, ".")
+	parts := splitKeyOnParts(path)
 	// Normalize path.
 	for k, v := range parts {
 		if v == "" {
@@ -425,6 +425,33 @@ func Get(cfg interface{}, path string) (interface{}, error) {
 	}
 
 	return cfg, nil
+}
+
+func splitKeyOnParts(key string) []string {
+	parts := []string{}
+
+	bracketOpened := false
+	var buffer bytes.Buffer
+	for _, char := range key {
+		if char == 91 || char == 93 { // [ ]
+			bracketOpened = char == 91
+			continue
+		}
+		if char == 46 && !bracketOpened { // point
+			parts = append(parts, buffer.String())
+			buffer.Reset()
+			continue
+		}
+
+		buffer.WriteRune(char)
+	}
+
+	if buffer.String() != "" {
+		parts = append(parts, buffer.String())
+		buffer.Reset()
+	}
+
+	return parts
 }
 
 // Set returns an error, in case when it is not possible to

--- a/config_test.go
+++ b/config_test.go
@@ -432,6 +432,27 @@ list:
 	expect(t, extended.UString("list.8"), "item8")
 }
 
+func TestComplexYamlKeys(t *testing.T) {
+	cfg, err := ParseYaml(`
+root:
+  field1: value1
+  field.something.2: value2
+  "field number 3":
+    field4: value3
+  field.something.4:
+    field5: value5
+    field.6: value6
+`)
+	expect(t, err, nil)
+
+	// result
+	expect(t, cfg.UString("root.field1"), "value1")
+	expect(t, cfg.UString("root.[field.something.2]"), "value2")
+	expect(t, cfg.UString("root.field number 3.field4"), "value3")
+	expect(t, cfg.UString("root.[field.something.4].field5"), "value5")
+	expect(t, cfg.UString("root.[field.something.4].[field.6]"), "value6")
+}
+
 func testConfig(t *testing.T, cfg *Config) {
 Loop:
 	for _, test := range configTests {


### PR DESCRIPTION
When necessary get key with dots inside, you can use square brackets for example:
yaml
```
root:
  field.with.dots: value
```
you can get value like this:
```
  config.UString("root.[field.with.dots]")
```