### PR TITLE
Fix lists being lost when extending #22

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -387,23 +387,6 @@ func TestCopy(t *testing.T) {
 	expect(t, yaml3, yaml4)
 }
 
-func TestExtendError(t *testing.T) {
-	cfg, err := ParseYaml(yamlString)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfg2, err := ParseYaml(`
-list:
-  key0: true
-map:
-  - true
-`)
-	var nilCfg *Config
-	extended, err := cfg.Extend(cfg2)
-	expect(t, extended, nilCfg)
-	expect(t, err.Error(), "Invalid list index at \"list.key0\"")
-}
-
 func TestExtend(t *testing.T) {
 	cfg, err := ParseYaml(yamlString)
 	if err != nil {
@@ -430,6 +413,21 @@ list:
 	expect(t, extended.UString("map.key8"), "value8")
 	expect(t, extended.UString("list.0"), "extend")
 	expect(t, extended.UString("list.8"), "item8")
+
+  // #22 Extending lists 
+
+  cfgList1, err := ParseJson(`{"list":[1,2]}`)
+  if err != nil {
+    t.Fatal(err)
+  }
+  cfgList2, err := ParseJson(`{"list":[1,2,3]}`)
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  cfgListExtended, err := cfgList1.Extend(cfgList2)
+  expect(t, err, nil)
+  expect(t, cfgListExtended.UInt("list.2"), 3)
 }
 
 func TestComplexYamlKeys(t *testing.T) {


### PR DESCRIPTION
This PR contains a new implementation of the Extend function. It makes it possible for lists to be extended as well. 

If this PR is merged it will somewhat change the behavior of the function. There are no more errors if the Config structs have a different structure. Look at the description above the implementation for a better overview.
 